### PR TITLE
[FJD-226] Convert old Booster version into separate recipe

### DIFF
--- a/booster_theme.info.yml
+++ b/booster_theme.info.yml
@@ -5,6 +5,7 @@ engine: twig
 type: theme
 base theme: radix
 dependencies:
+  - 'drupal:booster_lb'
   - 'drupal:sdc'
   - 'drupal:serialization'
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fivejars/booster_drupal_theme",
+    "name": "fivejars/drupal_booster_theme",
     "description": "Theme for Booster Drupal distribution.",
     "version": "1.x-dev",
     "type": "drupal-theme",

--- a/composer.libraries.json
+++ b/composer.libraries.json
@@ -1,0 +1,12 @@
+{
+    "repositories": {
+        "booster_theme_recipe": {
+            "type": "git",
+            "url": "https://github.com/fivejars/booster_recipe_booster_theme_radix_based.git",
+            "only": ["drupal_recipe/booster_theme"]
+        }
+    },
+    "require-dev": {
+        "drupal_recipe/booster_theme": "1.x-dev"
+    }
+}

--- a/composer.libraries.json
+++ b/composer.libraries.json
@@ -7,6 +7,7 @@
         }
     },
     "require-dev": {
+        "fivejars/booster_bootstrap_lb": "1.x-dev",
         "drupal_recipe/booster_theme": "1.x-dev"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"stylint-fix": "npx stylelint '**/*.scss' --fix",
 		"watch-poll": "mix watch -- --watch-options-poll=1000",
 		"hot": "mix watch --hot",
+		"build": "mix --production",
 		"production": "mix --production"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Steps for review:
- overview changes
- overview repository of separated recipe [GitHub - fivejars/booster_recipe_booster_theme: Sets up Booster (Radix based) theme as the default theme](https://github.com/fivejars/booster_recipe_booster_theme_radix_based)
- test with drupal_booster_docksal: [#6 [FJD-226] Convert old Booster version into separate recipe](https://bitbucket.org/fivejars/drupal_booster_docksal/pull-requests/6/overview)